### PR TITLE
Extract DittoLogger.setLogFile(logFile.toString()) from export logs

### DIFF
--- a/DittoExportLogs/src/main/java/live/ditto/dittoexportlogs/DittoLogManager.kt
+++ b/DittoExportLogs/src/main/java/live/ditto/dittoexportlogs/DittoLogManager.kt
@@ -11,7 +11,6 @@ import kotlin.io.path.isRegularFile
 
 object Config {
     private const val logsDirectoryName = "debug-logs"
-    private const val logFileName = "logs.txt"
     private const val zippedLogFileName = "logs.zip"
 
     val logsDirectory: Path by lazy {
@@ -20,18 +19,12 @@ object Config {
         directory
     }
 
-    val logFile: Path by lazy {
-        logsDirectory.resolve(logFileName)
-    }
-
     val zippedLogsFile: Path by lazy {
         Paths.get(System.getProperty("java.io.tmpdir"), zippedLogFileName)
     }
 }
 
 object DittoLogManager {
-    val logFile: Path
-        get() = Config.logFile
 
     fun createLogsZip(): Path {
         try {

--- a/DittoExportLogs/src/main/java/live/ditto/dittoexportlogs/ExportLogs.kt
+++ b/DittoExportLogs/src/main/java/live/ditto/dittoexportlogs/ExportLogs.kt
@@ -47,9 +47,6 @@ fun ExportLogs(onDismiss: () -> Unit) {
 }
 
 fun getZippedLogs(): Path {
-    DittoLogManager.logFile.let { logFile ->
-        DittoLogger.setLogFile(logFile.toString())
-    }
     return DittoLogManager.createLogsZip()
 }
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,37 @@ If you are using the Data Browser as a standalone app, there is a button, Start 
 ### 3. Export Logs
 Export Logs allows you to export a file of the logs from your applcation.  
 
+**Important**
+
+Before calling `ditto.startSync()` we need to set the `DittoLogger.setLogFileURL(<logFileURL>)`. This registers a file path where logs will be written to, whenever Ditto wants to issue a log (on top of emitting the log to the console). Use the `LogFileConfig` struct:
+
+```
+object LogFileConfig {
+    private const val logsDirectoryName = "debug-logs"
+    private const val logFileName = "logs.txt"
+
+    val logsDirectory: Path by lazy {
+        val directory = Paths.get(System.getProperty("java.io.tmpdir"), logsDirectoryName)
+        Files.createDirectories(directory)
+        directory
+    }
+
+    val logFile: Path by lazy {
+        logsDirectory.resolve(logFileName)
+    }
+}
+```
+
+and then before calling `ditto.startSync()` set the log file url with:
+
+```
+LogFileConfig.logFile.let { logFile ->
+    DittoLogger.setLogFile(logFile.toString())
+}
+```
+
+Now we can call `ExportLogs()`.
+
 ```kotlin
 DittoExportLogs(ditto = ditto)
 ```

--- a/app/src/main/java/live/ditto/dittotoolsapp/LogFileConfig.kt
+++ b/app/src/main/java/live/ditto/dittotoolsapp/LogFileConfig.kt
@@ -1,0 +1,17 @@
+package live.ditto.dittotoolsapp
+
+import java.nio.file.*
+object LogFileConfig {
+    private const val logsDirectoryName = "debug-logs"
+    private const val logFileName = "logs.txt"
+
+    val logsDirectory: Path by lazy {
+        val directory = Paths.get(System.getProperty("java.io.tmpdir"), logsDirectoryName)
+        Files.createDirectories(directory)
+        directory
+    }
+
+    val logFile: Path by lazy {
+        logsDirectory.resolve(logFileName)
+    }
+}

--- a/app/src/main/java/live/ditto/dittotoolsapp/MainActivity.kt
+++ b/app/src/main/java/live/ditto/dittotoolsapp/MainActivity.kt
@@ -40,6 +40,11 @@ class MainActivity : ComponentActivity() {
             val identity = DittoIdentity.OnlinePlayground(androidDependencies, appId = "YOUR_APPID", token = "YOUR_TOKEN", enableDittoCloudSync = true)
             ditto = Ditto(androidDependencies, identity)
             DittoLogger.minimumLogLevel = DittoLogLevel.DEBUG
+
+            LogFileConfig.logFile.let { logFile ->
+                DittoLogger.setLogFile(logFile.toString())
+            }
+
             ditto.startSync()
 
         } catch(e: DittoError) {


### PR DESCRIPTION
fixes #20 

There is a race condition happening from when you set DittoLogger.setLogFileURL and Ditto starts writing to the log file with when the file is exported. The first time you export the logs the log file is blank because the file is exported before Ditto has a chance to start writing to the log file. When we move DittoLogger.setLogFileURL out of the ExportLogs tool this gives Ditto enough time to write logs to the file before it is exported.

