### PR TITLE
Improves tools app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ DittoLogger.minimumLogLevel = DittoLogLevel.DEBUG
 ditto.startSync()
 ```
 
+_NOTICE:_ This project loads ditto's credentials from `local.properties`
+```properties
+ditto.onlinePlayground.appId="YOUR_APPID"
+ditto.onlinePlayground.token="YOUR_TOKEN"
+```
+
 
 There are four components in this package: Presence Viewer, Data Browser, Export Logs, Disk Usage.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,28 @@ plugins {
 
 apply from: "$rootProject.projectDir/gradle/android-common.gradle"
 
+def getValueFromPropertiesFile = { propFile, key ->
+    if (!propFile.isFile() || !propFile.canRead())
+        return null
+    def prop = new Properties()
+    def reader = propFile.newReader()
+    try {
+        prop.load(reader)
+    } finally {
+        reader.close()
+    }
+    return prop.get(key)
+}
+
+def getProperty = { name, defValue ->
+    def prop = project.properties[name] ?:
+            getValueFromPropertiesFile(project.rootProject.file('local.properties'), name)
+    return (null == prop) ? defValue : prop
+}
+
+ext.dittoOnlinePlaygroundAppId = getProperty('ditto.onlinePlayground.appId', "null")
+ext.dittoOnlinePlaygroundToken = getProperty('ditto.onlinePlayground.token', "null")
+
 android {
     namespace "live.ditto.dittotoolsapp"
 
@@ -12,6 +34,13 @@ android {
         applicationId "live.ditto.dittotoolsapp"
         versionCode 1
         versionName "1.0"
+
+        buildConfigField "String", "DITTO_ONLINE_PLAYGROUND_APP_ID", dittoOnlinePlaygroundAppId
+        buildConfigField "String", "DITTO_ONLINE_PLAYGROUND_TOKEN", dittoOnlinePlaygroundToken
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/live/ditto/dittotoolsapp/MainActivity.kt
+++ b/app/src/main/java/live/ditto/dittotoolsapp/MainActivity.kt
@@ -8,50 +8,41 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.dittodiskusage.DittoDiskUsage
 import ditto.live.dittopresenceviewer.DittoPresenceViewer
-import live.ditto.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import live.ditto.Ditto
+import live.ditto.DittoIdentity
+import live.ditto.DittoLogLevel
+import live.ditto.DittoLogger
 import live.ditto.android.DefaultAndroidDittoDependencies
 import live.ditto.dittodatabrowser.DittoDataBrowser
-import live.ditto.dittoexportlogs.ExportLogs
 import live.ditto.dittotoolsapp.ui.theme.DittoToolsAppTheme
 import live.ditto.transports.DittoSyncPermissions
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        lateinit var ditto: Ditto
-        try {
-            val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
-            val identity = DittoIdentity.OnlinePlayground(androidDependencies, appId = "YOUR_APPID", token = "YOUR_TOKEN", enableDittoCloudSync = true)
-            ditto = Ditto(androidDependencies, identity)
-            DittoLogger.minimumLogLevel = DittoLogLevel.DEBUG
-
-            LogFileConfig.logFile.let { logFile ->
-                DittoLogger.setLogFile(logFile.toString())
-            }
-
-            ditto.startSync()
-
-        } catch(e: DittoError) {
-            Log.e("Ditto error", e.message!!)
-        }
-
-        checkPermissions()
 
         setContent {
             DittoToolsAppTheme {
@@ -60,10 +51,58 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Root(ditto = ditto)
+                    var ditto: Ditto? by remember { mutableStateOf(null) }
+                    var dittoError: String? by remember { mutableStateOf(null) }
+
+                    LaunchedEffect(key1 = true) {
+                        try {
+                            ditto = createDitto()
+                            ditto?.startSync()
+                        } catch (e: Throwable) {
+                            dittoError = e.message.toString()
+                            Log.e("Ditto error", e.message.toString())
+                        }
+                    }
+
+                    dittoError?.let {
+                        DittoError(it)
+                        return@Surface
+                    }
+
+                    if (ditto == null) {
+                        Loading()
+                        return@Surface
+                    }
+
+                    ditto?.let {
+                        Root(ditto = it)
+                    }
                 }
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        checkPermissions()
+    }
+
+    private suspend fun createDitto(): Ditto = withContext(Dispatchers.Default) {
+        val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
+        val identity = DittoIdentity.OnlinePlayground(
+            androidDependencies,
+            appId = BuildConfig.DITTO_ONLINE_PLAYGROUND_APP_ID,
+            token = BuildConfig.DITTO_ONLINE_PLAYGROUND_TOKEN,
+            enableDittoCloudSync = true
+        )
+        val ditto = Ditto(androidDependencies, identity)
+        DittoLogger.minimumLogLevel = DittoLogLevel.DEBUG
+
+        LogFileConfig.logFile.let { logFile ->
+            DittoLogger.setLogFile(logFile.toString())
+        }
+
+        ditto
     }
 
     private fun checkPermissions() {
@@ -74,68 +113,60 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@Composable
-fun ShowViews(navController: NavHostController, ditto: Ditto) {
-    Box(modifier = Modifier.fillMaxSize()) {
-        var showExportDialog by remember { mutableStateOf(false) }
-
-        Column(
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .padding(16.dp)
-        ) {
-            Button(
-                onClick = {navController.navigate("dataBrowser")},
-                modifier = Modifier.padding(bottom = 8.dp)
-            ) {
-                Text("Data Browser")
-            }
-            Button(
-                onClick = { navController.navigate("diskUsage") },
-                modifier = Modifier.padding(bottom = 8.dp)
-            ) {
-                Text("Disk Usage")
-            }
-            Button(
-                onClick = { showExportDialog = !showExportDialog },
-                modifier = Modifier.padding(bottom = 8.dp)
-            ) {
-                Text("Export Logs")
-            }
-            Button(
-                onClick = { navController.navigate("presenceViewer") },
-                modifier = Modifier.padding(bottom = 8.dp)
-            ) {
-                Text("Presence Viewer")
-            }
-
-            if (showExportDialog) {
-                ExportLogs(onDismiss = { showExportDialog = false })
-            }
-        }
-    }
-}
 
 @Composable
-fun Root(ditto: Ditto) {
-
+private fun Root(ditto: Ditto) {
     val navController = rememberNavController()
 
     // A surface container using the 'background' color from the theme
     Surface(color = MaterialTheme.colorScheme.background) {
         NavHost(navController = navController, startDestination = "showViews") {
-            composable("showViews") { ShowViews(navController = navController, ditto = ditto) }
+            composable("showViews") {
+                ShowViewsScreen(
+                    navController = navController,
+                    ditto = ditto
+                )
+            }
             composable("dataBrowser") { DittoDataBrowser(ditto = ditto) }
-            composable("diskUsage") { DittoDiskUsage( ditto = ditto) }
-            composable("presenceViewer") { DittoPresenceViewer(ditto = ditto)}
+            composable("diskUsage") { DittoDiskUsage(ditto = ditto) }
+            composable("presenceViewer") { DittoPresenceViewer(ditto = ditto) }
         }
     }
 }
 
+@Composable
+private fun DittoError(text: String) {
+    DittoToolsAppTheme {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .align(Alignment.Center)
+            ) {
+                Text(
+                    text = "Ditto Error",
+                    fontWeight = FontWeight.Bold
+                )
+                Divider(modifier = Modifier.padding(vertical = 4.dp))
+                Text(text = text)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Loading() {
+    DittoToolsAppTheme {
+        Box(modifier = Modifier.fillMaxSize()) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}
 
 @Preview(showBackground = true)
 @Composable
-fun DefaultPreview() {
-    DittoToolsAppTheme {
-    }
+private fun DefaultPreview() {
+    DittoToolsAppTheme {}
 }

--- a/app/src/main/java/live/ditto/dittotoolsapp/ShowViewsScreen.kt
+++ b/app/src/main/java/live/ditto/dittotoolsapp/ShowViewsScreen.kt
@@ -1,0 +1,61 @@
+package live.ditto.dittotoolsapp
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import live.ditto.Ditto
+import live.ditto.dittoexportlogs.ExportLogs
+
+@Composable
+fun ShowViewsScreen(navController: NavHostController, ditto: Ditto) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        var showExportDialog by remember { mutableStateOf(false) }
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp)
+        ) {
+            Button(
+                onClick = {navController.navigate("dataBrowser")},
+                modifier = Modifier.padding(bottom = 8.dp)
+            ) {
+                Text("Data Browser")
+            }
+            Button(
+                onClick = { navController.navigate("diskUsage") },
+                modifier = Modifier.padding(bottom = 8.dp)
+            ) {
+                Text("Disk Usage")
+            }
+            Button(
+                onClick = { showExportDialog = !showExportDialog },
+                modifier = Modifier.padding(bottom = 8.dp)
+            ) {
+                Text("Export Logs")
+            }
+            Button(
+                onClick = { navController.navigate("presenceViewer") },
+                modifier = Modifier.padding(bottom = 8.dp)
+            ) {
+                Text("Presence Viewer")
+            }
+
+            if (showExportDialog) {
+                ExportLogs(onDismiss = { showExportDialog = false })
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Reads ditto's credentials from local.properties.
- Creates ditto in a background thread. 
- Adds support for **loading** and **error**.
- Permissions are checked each time the app resumes.
- Moves `ShowViews` into its own file `ShowViewsScreen`
- Formats code based on Android Studio defaults.

## Images
![tools-ditto-error](https://github.com/getditto/DittoAndroidTools/assets/5747647/9c81ac1e-d63b-4ae1-b2b8-3f14cd276b4b)
