### PR TITLE
Ui improvements for DiskUsage

### DIFF
--- a/DittoDiskUsage/build.gradle
+++ b/DittoDiskUsage/build.gradle
@@ -17,8 +17,11 @@ android {
 dependencies {
     androidTestImplementation libs.androidx.test.ext.junit
 
+    debugImplementation libs.androidx.compose.ui.uiTooling
+
     implementation libs.androidx.compose.material3.material3
     implementation libs.androidx.compose.ui.ui
+    implementation libs.androidx.compose.ui.uiToolingPreview
     implementation libs.androidx.navigation.navigationCompose
     implementation libs.live.ditto.ditto
 

--- a/DittoDiskUsage/src/main/java/com/example/dittodiskusage/DiskUsageView.kt
+++ b/DittoDiskUsage/src/main/java/com/example/dittodiskusage/DiskUsageView.kt
@@ -1,30 +1,40 @@
 package com.example.dittodiskusage
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import live.ditto.DiskUsageItem
+import live.ditto.dittodiskusage.R
 import java.text.DecimalFormat
 import kotlin.math.log10
 import kotlin.math.pow
+
+private val ScreenTypography = Typography()
 
 data class DiskUsage(
     val relativePath: String = "ditto/ditto_store",
@@ -39,7 +49,7 @@ data class DiskUsageState(
     val children: List<DiskUsage> = listOf(DiskUsage()),
 )
 
-class DiskUsageViewModel: ViewModel() {
+class DiskUsageViewModel : ViewModel() {
     /* Private mutable state */
     private val _uiState = MutableStateFlow(DiskUsageState())
 
@@ -84,72 +94,117 @@ class DiskUsageViewModel: ViewModel() {
 @Composable
 fun DiskUsageView(
     viewModel: DiskUsageViewModel = viewModel()
-    ) {
+) {
     val uiState by viewModel.uiState.collectAsState()
+    DiskUsageView(uiState = uiState)
+}
 
+@Composable
+private fun Item(
+    leftText: String,
+    rightText: String,
+    style: TextStyle,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = leftText,
+            style = style
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Text(
+            text = rightText,
+            style = style
+        )
+    }
+}
+
+@Composable
+private fun DiskUsageView(uiState: DiskUsageState) {
     Surface {
-        Column(
-            modifier = Modifier.padding(24.dp)
-        ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            Spacer(modifier = Modifier.height(24.dp))
+
             Text(
-                text = "Disk Usage",
-                fontSize = 24.sp,
+                text = stringResource(R.string.disk_usage),
+                style = ScreenTypography.headlineLarge,
                 modifier = Modifier.align(Alignment.CenterHorizontally)
             )
 
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-            ) {
-                items(uiState.children) { child ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text(
-                                text = child.relativePath,
-                                fontSize = 18.sp
-                            )
-                        }
+            Spacer(modifier = Modifier.height(24.dp))
 
-                        Column {
-                            Text(
-                                text = child.size,
-                                fontSize = 18.sp,
-                                textAlign = TextAlign.End
-                            )
-                        }
-                    }
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                items(uiState.children) { diskUsage ->
+                    Item(
+                        leftText = diskUsage.relativePath,
+                        rightText = diskUsage.size,
+                        style = ScreenTypography.bodyLarge
+                    )
                 }
 
                 item {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text(
-                                text = "Total",
-                                fontSize = 18.sp
-                            )
-                        }
+                    Divider(Modifier.padding(vertical = 8.dp))
+                }
 
-                        Column {
-                            Text(
-                                text = uiState.totalSize,
-                                fontSize = 18.sp,
-                                textAlign = TextAlign.End
-                            )
-                        }
-                    }
+                item {
+                    Item(
+                        leftText = stringResource(R.string.total),
+                        rightText = uiState.totalSize,
+                        style = ScreenTypography.titleLarge
+                    )
                 }
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun ItemPreview() {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Item(
+            leftText = "foo/bar",
+            rightText = "400",
+            style = ScreenTypography.bodyLarge
+        )
+    }
+}
+
+
+@Preview
+@Composable
+private fun ItemTotalPreview() {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Item(
+            leftText = "Total",
+            rightText = "400",
+            style = ScreenTypography.titleLarge
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DiskUsageViewPreview() {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        DiskUsageView(
+            uiState = DiskUsageState(
+                rootPath = "root",
+                totalSizeInBytes = 200,
+                totalSize = "400",
+                children = listOf(
+                    DiskUsage(),
+                    DiskUsage(size = "200"),
+                    DiskUsage(size = "200"),
+                    DiskUsage(size = "200"),
+                    DiskUsage(size = "200"),
+                    DiskUsage(size = "200"),
+                )
+            )
+        )
     }
 }

--- a/DittoDiskUsage/src/main/res/values/strings.xml
+++ b/DittoDiskUsage/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="disk_usage">Disk Usage</string>
+    <string name="total">Total</string>
+</resources>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,12 @@ dependencies {
     implementation libs.live.ditto.databrowser
     implementation libs.live.ditto.exportlogs
     implementation libs.live.ditto.presenceviewer
-    implementation libs.live.ditto.diskusage
+
+    // TODO: Use maven version once this ticket is done
+    //       https://github.com/getditto/DittoAndroidTools/issues/31
+    implementation(project(":DittoDiskUsage"))
+    // implementation libs.live.ditto.diskusage
+
     implementation libs.live.ditto.health
     implementation(project(":DittoPresenceDegradationReporter"))
 


### PR DESCRIPTION
- Consolidates UI for items and total into a common composable.
- Adds UI previews for all the UI elements.
- Fixes spaces based on Google Material UI guidances.

| Before | After |
| :- | :- |
| ![before](https://github.com/getditto/DittoAndroidTools/assets/5747647/9ea196a0-8f20-4308-9d9f-1c748e432731) | ![after](https://github.com/getditto/DittoAndroidTools/assets/5747647/05f7afd8-1178-4b27-974d-81f2e552faff) | 

close https://github.com/getditto/DittoAndroidTools/issues/31