### PR TITLE
Update heartbeat tool collection name, update gradle dependency constraint

### DIFF
--- a/DittoDataBrowser/build.gradle
+++ b/DittoDataBrowser/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }

--- a/DittoDiskUsage/build.gradle
+++ b/DittoDiskUsage/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }

--- a/DittoExportLogs/build.gradle
+++ b/DittoExportLogs/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }

--- a/DittoExporter/build.gradle
+++ b/DittoExporter/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }

--- a/DittoHealth/build.gradle
+++ b/DittoHealth/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }

--- a/DittoHeartbeat/build.gradle
+++ b/DittoHeartbeat/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }

--- a/DittoHeartbeat/src/main/java/live.ditto.dittoheartbeat/Constants.kt
+++ b/DittoHeartbeat/src/main/java/live.ditto.dittoheartbeat/Constants.kt
@@ -1,4 +1,4 @@
 package live.ditto.dittoheartbeat
 
 const val HEARTBEAT_COLLECTION_SCHEMA_VALUE = "1"
-const val HEARTBEAT_COLLECTION_COLLECTION_NAME = "__dittotools_devices"
+const val HEARTBEAT_COLLECTION_COLLECTION_NAME = "dittotools_devices"

--- a/DittoPresenceDegradationReporter/build.gradle
+++ b/DittoPresenceDegradationReporter/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }

--- a/DittoPresenceViewer/build.gradle
+++ b/DittoPresenceViewer/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     constraints {
         implementation(libs.live.ditto.ditto) {
             version {
-                strictly '>= 4.4.0'
+                strictly "[4.4.0,)"
             }
         }
     }


### PR DESCRIPTION
Update to the heartbeat tool collection name.

I also noticed that when trying to build, references to the ditto library weren't being resolved. Looking into it further, it failed to pull in the ditto library because it "couldn't find a version that matched the dependency constraints". This happened because the format of how we requested the minimum version was incorrect.

See [Delcaring RIch Versions](https://docs.gradle.org/current/userguide/rich_versions.html) on Gradle website for more info

Basically you express the version you want either as a specific version (e.g. "2.3.9") or as a range (which is what I've done here - I've asked for at least 4.4.0 inclusive and above)

Closes https://github.com/getditto/DittoAndroidTools/issues/64