### PR TITLE
make fileprovider authority dynamic

### DIFF
--- a/DittoExportLogs/src/main/AndroidManifest.xml
+++ b/DittoExportLogs/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <application>
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="live.ditto.dittotoolsapp.fileprovider"
+            android:authorities="${applicationId}.live.ditto.dittotoolsapp.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
 


### PR DESCRIPTION
This PR enables multiple apps that use the Export Logs tool to be installed at the same time.