### PR TITLE
Cleanup demo app dependencies. Add local testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,10 +409,9 @@ remove/comment out: `implementation libs.live.ditto.databrowser`
 
 ### Testing in an External Project
 
-1. In your `local.properties` file for `DittoAndroidTools` add a `LIBRARY_VERSION` variable with a version that doesn't exist (e.g. 82.0.0). Do NOT use quotes. The entry should look something like: `LIBRARY_VERSION=82.0.0`
-2. Run `./gradlew publishToMavenLocal`
-3. In your external project add the `mavenLocal()` entry to your list of repository sources
-4. When importing a tool, use the version you specified earlier
+1. Run `./gradlew publishToMavenLocal`
+2. In your external project add the `mavenLocal()` entry to your list of repository sources
+3. When importing a tool, the version will be `SNAPSHOT`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ ditto.onlinePlayground.appId="YOUR_APPID"
 ditto.onlinePlayground.token="YOUR_TOKEN"
 ```
 
+## Testing Changes Locally
+
+There are two ways you can test things locally. Either in the demo app, or in an external project.
+
+### Testing in the Demo App Locally
+
+To test your changes to a module in the demo app, simply import the local module, making sure to comment out/delete the version catalog import. For example, if you made changes to DittoDataBrowser you would
+
+add: `implementation(project(":DittoDataBrowser"))`
+remove/comment out: `implementation libs.live.ditto.databrowser`
+
+### Testing in an External Project
+
+1. In your `local.properties` file for `DittoAndroidTools` add a `LIBRARY_VERSION` variable with a version that doesn't exist (e.g. 82.0.0). Do NOT use quotes. The entry should look something like: `LIBRARY_VERSION=82.0.0`
+2. Run `./gradlew publishToMavenLocal`
+3. In your external project add the `mavenLocal()` entry to your list of repository sources
+4. When importing a tool, use the version you specified earlier
 
 There are five components in this package: Presence Viewer, Data Browser, Export Logs, Disk Usage, Health.
 

--- a/README.md
+++ b/README.md
@@ -52,24 +52,6 @@ ditto.onlinePlayground.appId="YOUR_APPID"
 ditto.onlinePlayground.token="YOUR_TOKEN"
 ```
 
-## Testing Changes Locally
-
-There are two ways you can test things locally. Either in the demo app, or in an external project.
-
-### Testing in the Demo App Locally
-
-To test your changes to a module in the demo app, simply import the local module, making sure to comment out/delete the version catalog import. For example, if you made changes to DittoDataBrowser you would
-
-add: `implementation(project(":DittoDataBrowser"))`
-remove/comment out: `implementation libs.live.ditto.databrowser`
-
-### Testing in an External Project
-
-1. In your `local.properties` file for `DittoAndroidTools` add a `LIBRARY_VERSION` variable with a version that doesn't exist (e.g. 82.0.0). Do NOT use quotes. The entry should look something like: `LIBRARY_VERSION=82.0.0`
-2. Run `./gradlew publishToMavenLocal`
-3. In your external project add the `mavenLocal()` entry to your list of repository sources
-4. When importing a tool, use the version you specified earlier
-
 There are five components in this package: Presence Viewer, Data Browser, Export Logs, Disk Usage, Health.
 
 ### 1. Presence Viewer
@@ -413,6 +395,24 @@ Maven:
     <version>YOUR_LIBRARY_VERSION</version>
 </dependency>
 ```
+
+## Testing Changes Locally
+
+There are two ways you can test things locally. Either in the demo app, or in an external project.
+
+### Testing in the Demo App Locally
+
+To test your changes to a module in the demo app, simply import the local module, making sure to comment out/delete the version catalog import. For example, if you made changes to DittoDataBrowser you would
+
+add: `implementation(project(":DittoDataBrowser"))`
+remove/comment out: `implementation libs.live.ditto.databrowser`
+
+### Testing in an External Project
+
+1. In your `local.properties` file for `DittoAndroidTools` add a `LIBRARY_VERSION` variable with a version that doesn't exist (e.g. 82.0.0). Do NOT use quotes. The entry should look something like: `LIBRARY_VERSION=82.0.0`
+2. Run `./gradlew publishToMavenLocal`
+3. In your external project add the `mavenLocal()` entry to your list of repository sources
+4. When importing a tool, use the version you specified earlier
 
 ## License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,25 +5,6 @@ plugins {
 
 apply from: "$rootProject.projectDir/gradle/android-common.gradle"
 
-def getValueFromPropertiesFile = { propFile, key ->
-    if (!propFile.isFile() || !propFile.canRead())
-        return null
-    def prop = new Properties()
-    def reader = propFile.newReader()
-    try {
-        prop.load(reader)
-    } finally {
-        reader.close()
-    }
-    return prop.get(key)
-}
-
-def getProperty = { name, defValue ->
-    def prop = project.properties[name] ?:
-            getValueFromPropertiesFile(project.rootProject.file('local.properties'), name)
-    return (null == prop) ? defValue : prop
-}
-
 ext.dittoOnlinePlaygroundAppId = getProperty('ditto.onlinePlayground.appId', "null")
 ext.dittoOnlinePlaygroundToken = getProperty('ditto.onlinePlayground.token', "null")
 
@@ -63,6 +44,7 @@ dependencies {
     implementation libs.live.ditto.heartbeat
     implementation libs.live.ditto.presencedegradationreporter
     implementation libs.live.ditto.healthmetrics
+    implementation libs.live.ditto.exporter
 
     testImplementation libs.junit.junit
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,19 +58,11 @@ dependencies {
     implementation libs.live.ditto.databrowser
     implementation libs.live.ditto.exportlogs
     implementation libs.live.ditto.presenceviewer
-    implementation project(":DittoExporter")
-
-    // TODO: Use maven version once this ticket is done
-    implementation(project(":DittoHeartbeat"))
-
-    // TODO: Use maven version once this ticket is done
-    //       https://github.com/getditto/DittoAndroidTools/issues/31
-    implementation(project(":DittoDiskUsage"))
-    // implementation libs.live.ditto.diskusage
-
-    implementation(project(":DittoHealth"))
-    implementation(project(":DittoPresenceDegradationReporter"))
-    implementation(project(":DittoHealthMetrics"))
+    implementation libs.live.ditto.diskusage
+    implementation libs.live.ditto.health
+    implementation libs.live.ditto.heartbeat
+    implementation libs.live.ditto.presencedegradationreporter
+    implementation libs.live.ditto.healthmetrics
 
     testImplementation libs.junit.junit
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,8 +5,8 @@ plugins {
 
 apply from: "$rootProject.projectDir/gradle/android-common.gradle"
 
-ext.dittoOnlinePlaygroundAppId = getProperty('ditto.onlinePlayground.appId', "null")
-ext.dittoOnlinePlaygroundToken = getProperty('ditto.onlinePlayground.token', "null")
+ext.dittoOnlinePlaygroundAppId = getValueFromLocalProperties('ditto.onlinePlayground.appId', "null")
+ext.dittoOnlinePlaygroundToken = getValueFromLocalProperties('ditto.onlinePlayground.token', "null")
 
 android {
     namespace "live.ditto.dittotoolsapp"

--- a/app/src/main/java/live/ditto/dittotoolsapp/HeartbeatView.kt
+++ b/app/src/main/java/live/ditto/dittotoolsapp/HeartbeatView.kt
@@ -27,10 +27,9 @@ import java.util.*
 fun ShowHeartbeatData(ditto: Ditto) {
 
     var heartbeatInfo by remember { mutableStateOf<DittoHeartbeatInfo?>(null) }
-    var healthMetricProviders: MutableList<HealthMetricProvider> = mutableListOf()
+    val healthMetricProviders: MutableList<HealthMetricProvider> = mutableListOf()
     val diskUsageViewModel = DiskUsageViewModel()
     healthMetricProviders.add(diskUsageViewModel)
-//    healthMetricProviders.add(diskUsageViewModel)
 
     val config = DittoHeartbeatConfig(
         //id for testing only. Unique id will not persist

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ def getValueFromPropertiesFile = { propFile, key ->
     return prop.get(key)
 }
 
-ext.getProperty = { name, defValue ->
+ext.getValueFromLocalProperties = { name, defValue ->
     def prop = project.properties[name] ?:
             getValueFromPropertiesFile(project.rootProject.file('local.properties'), name)
     return (null == prop) ? defValue : prop

--- a/build.gradle
+++ b/build.gradle
@@ -5,3 +5,22 @@ plugins {
 }
 
 version = findProperty("LIBRARY_VERSION")
+
+def getValueFromPropertiesFile = { propFile, key ->
+    if (!propFile.isFile() || !propFile.canRead())
+        return null
+    def prop = new Properties()
+    def reader = propFile.newReader()
+    try {
+        prop.load(reader)
+    } finally {
+        reader.close()
+    }
+    return prop.get(key)
+}
+
+ext.getProperty = { name, defValue ->
+    def prop = project.properties[name] ?:
+            getValueFromPropertiesFile(project.rootProject.file('local.properties'), name)
+    return (null == prop) ? defValue : prop
+}

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -38,8 +38,7 @@ afterEvaluate {
                 artifactId libraryArtifactId
                 groupId = 'live.ditto'
 
-                def versionPropertyName = "LIBRARY_VERSION"
-                version = hasProperty(versionPropertyName) ? findProperty(versionPropertyName) : getValueFromLocalProperties(versionPropertyName, null)
+                version = findProperty("LIBRARY_VERSION") ?: "SNAPSHOT"
 
                 pom {
                     name = 'Ditto Tools'

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -39,7 +39,7 @@ afterEvaluate {
                 groupId = 'live.ditto'
 
                 def versionPropertyName = "LIBRARY_VERSION"
-                version = hasProperty(versionPropertyName) ? findProperty(versionPropertyName) : getProperty(versionPropertyName, null)
+                version = hasProperty(versionPropertyName) ? findProperty(versionPropertyName) : getValueFromLocalProperties(versionPropertyName, null)
 
                 pom {
                     name = 'Ditto Tools'

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -16,7 +16,7 @@ def base64Decode(encodedString){
 def readLocalProperty(propertyName) {
     Properties properties = new Properties()
     properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    return properties.getProperty(propertyName, "")
+    return properties.getProperty(propertyName)
 }
 
 signing {

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -13,12 +13,6 @@ def base64Decode(encodedString){
     return null;
 }
 
-def readLocalProperty(propertyName) {
-    Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    return properties.getProperty(propertyName)
-}
-
 signing {
     if(project.hasProperty("PUBLISH_TO_MAVEN_CENTRAL")){
         useInMemoryPgpKeys(base64Decode(signingKeyBase64), signingPassword)
@@ -45,7 +39,7 @@ afterEvaluate {
                 groupId = 'live.ditto'
 
                 def versionPropertyName = "LIBRARY_VERSION"
-                version = hasProperty(versionPropertyName) ? findProperty(versionPropertyName) : readLocalProperty(versionPropertyName)
+                version = hasProperty(versionPropertyName) ? findProperty(versionPropertyName) : getProperty(versionPropertyName, null)
 
                 pom {
                     name = 'Ditto Tools'

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -13,6 +13,12 @@ def base64Decode(encodedString){
     return null;
 }
 
+def readLocalProperty(propertyName) {
+    Properties properties = new Properties()
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    return properties.getProperty(propertyName, "")
+}
+
 signing {
     if(project.hasProperty("PUBLISH_TO_MAVEN_CENTRAL")){
         useInMemoryPgpKeys(base64Decode(signingKeyBase64), signingPassword)
@@ -37,7 +43,9 @@ afterEvaluate {
                 from components.release
                 artifactId libraryArtifactId
                 groupId = 'live.ditto'
-                version = findProperty("LIBRARY_VERSION")
+
+                def versionPropertyName = "LIBRARY_VERSION"
+                version = hasProperty(versionPropertyName) ? findProperty(versionPropertyName) : readLocalProperty(versionPropertyName)
 
                 pom {
                     name = 'Ditto Tools'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ androidx-test-ext = "1.1.5"
 androidx-webkit = "1.7.0"
 datastorePreferences = "1.0.0"
 ditto = "4.5.0"
-live-ditto-tools = "1.0.0"
+live-ditto-tools = "1.1.0"
 
 junit = "4.13.2"
 kotlin-gradle-plugin = "1.8.10"
@@ -38,7 +38,9 @@ live-ditto-databrowser = { module = "live.ditto:dittodatabrowser", version.ref =
 live-ditto-exportlogs = { module = "live.ditto:dittoexportlogs", version.ref = "live-ditto-tools" }
 live-ditto-diskusage = { module = "live.ditto:dittodiskusage", version.ref = "live-ditto-tools" }
 live-ditto-presenceviewer = { module = "live.ditto:dittopresenceviewer", version.ref = "live-ditto-tools" }
+live-ditto-presencedegradationreporter = { module = "live.ditto:presencedegradationreporter", version.ref = "live-ditto-tools" }
 live-ditto-health = { module = "live.ditto:health", version.ref = "live-ditto-tools" }
+live-ditto-healthmetrics = { module = "live.ditto:healthmetrics", version.ref = "live-ditto-tools" }
 live-ditto-heartbeat = { module = "live.ditto:dittoheartbeat", version.ref = "live-ditto-tools" }
 live-ditto-ditto = { group = "live.ditto", name = "ditto", version.ref = "ditto" }
 junit-junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 androidx-webkit-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidx-webkit" }
 live-ditto-databrowser = { module = "live.ditto:dittodatabrowser", version.ref = "live-ditto-tools" }
 live-ditto-exportlogs = { module = "live.ditto:dittoexportlogs", version.ref = "live-ditto-tools" }
+live-ditto-exporter = { module = "live.ditto:dittoexporter", version.ref = "live-ditto-tools" }
 live-ditto-diskusage = { module = "live.ditto:dittodiskusage", version.ref = "live-ditto-tools" }
 live-ditto-presenceviewer = { module = "live.ditto:dittopresenceviewer", version.ref = "live-ditto-tools" }
 live-ditto-presencedegradationreporter = { module = "live.ditto:presencedegradationreporter", version.ref = "live-ditto-tools" }


### PR DESCRIPTION
Fixes https://github.com/getditto/DittoAndroidTools/issues/104

Cleaned up the dependencies.

Also added instructions if someone wanted to test tools changes either locally or in an external project.

Added the ability to set the local version number in `local.properties` file (since the file doesn't get committed, less chance of something changing that we don't want). When running `./gradlew publishToMavenLocal` it will use the version set there. This should NOT affect publishing to Maven or the Github action - those should work as expected.