### PR TITLE
Update Export Data icon and ReadMe

### DIFF
--- a/DittoDiskUsage/src/main/java/com/example/dittodiskusage/DiskUsageView.kt
+++ b/DittoDiskUsage/src/main/java/com/example/dittodiskusage/DiskUsageView.kt
@@ -1,16 +1,17 @@
 package com.example.dittodiskusage
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Divider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -25,7 +26,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -75,13 +75,14 @@ private fun DiskUsageView(
 
                 IconButton(
                     enabled = !isExportDialogOpen,
-                    onClick = { isExportDialogOpen = true }
+                    onClick = { isExportDialogOpen = true },
+                    modifier = Modifier
+                        .widthIn(min = 60.dp) // Ensure a minimum width for the button
+                        .background(Color.LightGray, shape = RoundedCornerShape(8.dp))
+                        .padding(horizontal = 5.dp)
                 ) {
-                    Icon(
-                        painter = painterResource(R.drawable.folder_zip),
-                        contentDescription = null,
-                        modifier = Modifier.size(44.dp),
-                        tint = Color.DarkGray
+                    Text(
+                        text = "Export"
                     )
                 }
             }

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ ditto.onlinePlayground.appId="YOUR_APPID"
 ditto.onlinePlayground.token="YOUR_TOKEN"
 ```
 
-There are five components in this package: Presence Viewer, Data Browser, Export Logs, Disk Usage/Export Data, Health.
-
 ### 1. Presence Viewer
 The Presence Viewer displays a mesh graph that allows you to see all connected peers within the mesh and the transport that each peer is using to make a connection.  
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DittoAndroidTools
 
-DittoAndroidTools are diagnostic tools for Ditto. You can view connected peers, export debug logs, browse collections/documents and see Ditto's disk usage.
+DittoAndroidTools are diagnostic tools for Ditto. You can view connected peers, export debug logs, browse collections/documents and see Ditto's disk usage/ export this data.
 
 These tools are available through Maven.
 
@@ -27,7 +27,7 @@ repositories {
 | 1. Presence Viewer               | `'live.ditto:dittopresenceviewer:LIBRARY_VERSION'`         |
 | 2. Data Browser                  | `'live.ditto:dittodatabrowser:LIBRARY_VERSION'`            |
 | 3. Export Logs                   | `'live.ditto:dittoexportlogs:LIBRARY_VERSION'`             |
-| 4. Disk Usage                    | `'live.ditto:dittodiskusage:LIBRARY_VERSION'`              |
+| 4. Disk Usage/Export Data        | `'live.ditto:dittodiskusage:LIBRARY_VERSION'`              |
 | 5. Health                        | `'live.ditto:health:LIBRARY_VERSION'`                      |
 | 6. Heartbeat                     | `'live.ditto:dittoheartbeat:LIBRARY_VERSION'`              |
 | 7. Presence Degradation Reporter | `'live.ditto:presencedegradationreporter:LIBRARY_VERSION'` |
@@ -52,7 +52,7 @@ ditto.onlinePlayground.appId="YOUR_APPID"
 ditto.onlinePlayground.token="YOUR_TOKEN"
 ```
 
-There are five components in this package: Presence Viewer, Data Browser, Export Logs, Disk Usage, Health.
+There are five components in this package: Presence Viewer, Data Browser, Export Logs, Disk Usage/Export Data, Health.
 
 ### 1. Presence Viewer
 The Presence Viewer displays a mesh graph that allows you to see all connected peers within the mesh and the transport that each peer is using to make a connection.  
@@ -178,9 +178,10 @@ Maven:
 </dependency>
 ```
 
-### 4. Disk Usage
+### 4. Disk Usage/ Export Data
 
 Disk Usage allows you to see Ditto's file space usage.  
+Export Data allows you to export the Ditto directory.
 
 ```kotlin
 DittoDiskUsage(ditto = ditto)


### PR DESCRIPTION
fixes #108 
See also #109 

Updates the ReadMe to include more data.
New Icon for Exporting data
<img width="293" alt="diskUsage" src="https://github.com/user-attachments/assets/80261b27-1f33-4533-9420-d04c42c7f6fb">
