### PR TITLE
Update grade dependencies and fix for some crashes

### DIFF
--- a/DittoDiskUsage/build.gradle
+++ b/DittoDiskUsage/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation libs.androidx.compose.ui.ui
     implementation libs.androidx.compose.ui.uiToolingPreview
     implementation libs.androidx.navigation.navigationCompose
-    implementation project(path: ':DittoHealthMetrics')
+    implementation libs.live.ditto.healthmetrics
     implementation libs.live.ditto.ditto
     // Dependency constraint for ditto
     constraints {
@@ -31,7 +31,7 @@ dependencies {
             }
         }
     }
-    implementation project(":DittoExporter")
+    implementation libs.live.ditto.exporter
 
     implementation platform(libs.androidx.compose.composeBom)
 

--- a/DittoDiskUsage/src/main/java/live/ditto/dittodiskusage/usecase/GetDiskUsageMetrics.kt
+++ b/DittoDiskUsage/src/main/java/live/ditto/dittodiskusage/usecase/GetDiskUsageMetrics.kt
@@ -16,7 +16,7 @@ class GetDiskUsageMetrics {
     fun execute(currentState: DiskUsageState): HealthMetric {
 
         val dittoStoreSize: Int =
-            currentState.children.first { shortRelativePath(it.relativePath) == DITTO_STORE }.sizeInBytes
+            currentState.children.firstOrNull { shortRelativePath(it.relativePath) == DITTO_STORE }?.sizeInBytes ?: 0
         val dittoReplicationSize: Int = currentState.children.firstOrNull {
             shortRelativePath(it.relativePath) == DITTO_REPLICATION }?.sizeInBytes ?: 0
 

--- a/DittoExportLogs/build.gradle
+++ b/DittoExportLogs/build.gradle
@@ -27,7 +27,7 @@ dependencies {
             }
         }
     }
-    implementation project(":DittoExporter")
+    implementation libs.live.ditto.exporter
     implementation platform(libs.androidx.compose.composeBom)
 
     testImplementation libs.junit.junit

--- a/DittoHealth/build.gradle
+++ b/DittoHealth/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation libs.androidx.compose.ui.uiTooling
     implementation libs.androidx.compose.ui.uiToolingPreview
     implementation libs.androidx.navigation.navigationCompose
-    implementation project(path: ':DittoHealthMetrics')
+    implementation libs.live.ditto.healthmetrics
     implementation libs.live.ditto.ditto
     // Dependency constraint for ditto
     constraints {

--- a/DittoHeartbeat/build.gradle
+++ b/DittoHeartbeat/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation libs.androidx.compose.ui.uiTooling
     implementation libs.androidx.compose.ui.uiToolingPreview
     implementation libs.androidx.navigation.navigationCompose
-    implementation project(path: ':DittoHealthMetrics')
+    implementation libs.live.ditto.healthmetrics
     implementation libs.live.ditto.ditto
     // Dependency constraint for ditto
     constraints {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,16 +36,7 @@ dependencies {
 
     implementation platform(libs.androidx.compose.composeBom)
 
-    implementation(project(":DittoToolsViewer"))
-    implementation libs.live.ditto.databrowser
-    implementation libs.live.ditto.exportlogs
-    implementation libs.live.ditto.presenceviewer
-    implementation libs.live.ditto.diskusage
-    implementation libs.live.ditto.health
-    implementation libs.live.ditto.heartbeat
-    implementation libs.live.ditto.presencedegradationreporter
-    implementation libs.live.ditto.healthmetrics
-    implementation libs.live.ditto.exporter
+    implementation libs.live.ditto.toolsviewer
 
     testImplementation libs.junit.junit
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,8 @@ androidx-navigation = "2.5.3"
 androidx-test-ext = "1.1.5"
 androidx-webkit = "1.7.0"
 datastorePreferences = "1.0.0"
-ditto = "4.7.4"
-live-ditto-tools = "2.0.0"
+ditto = "4.8.0"
+live-ditto-tools = "2.1.0"
 
 junit = "4.13.2"
 kotlin-gradle-plugin = "1.8.10"
@@ -34,6 +34,7 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 androidx-navigation-navigationCompose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidx-navigation" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext" }
 androidx-webkit-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidx-webkit" }
+live-ditto-toolsviewer = { module = "live.ditto:dittotoolsviewer", version.ref = "live-ditto-tools" }
 live-ditto-databrowser = { module = "live.ditto:dittodatabrowser", version.ref = "live-ditto-tools" }
 live-ditto-exportlogs = { module = "live.ditto:dittoexportlogs", version.ref = "live-ditto-tools" }
 live-ditto-exporter = { module = "live.ditto:dittoexporter", version.ref = "live-ditto-tools" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ androidx-navigation = "2.5.3"
 androidx-test-ext = "1.1.5"
 androidx-webkit = "1.7.0"
 datastorePreferences = "1.0.0"
-ditto = "4.8.0"
+ditto = "4.7.4"
 live-ditto-tools = "2.1.0"
 
 junit = "4.13.2"

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }


### PR DESCRIPTION
Now that we've published all tools we should be pulling in the dependencies using gradle as opposed to specifying the local project(s).

I also noticed a few crashes when integrating with apps outside the project. Export logs and Heartbeat for example. In it's current state you can reproduce those crashes by pulling in Tools Viewer 2.1.0 (latest published) and trying to use Export Logs or Heartbeat. I tested this with the demo app, chat app and Android PoS demo [of which I am working on locally].

To see it fixed, run `./gradlew publishToMavenLocal` for tools, then pull in the local tools version (`SNAPSHOT`).

Export Logs crashed due to a null value being returned from a predicate.
Heartbeat crashed because gradle couldn't figure out which class to use for `DittoCollection.upsert()`.

Once these fixes are in, I'd like to publish a 2.1.1. version.