### PR TITLE
update naming of peerKey to peerKeyString

### DIFF
--- a/DittoHeartbeat/src/main/java/live.ditto.dittoheartbeat/Heartbeat.kt
+++ b/DittoHeartbeat/src/main/java/live.ditto.dittoheartbeat/Heartbeat.kt
@@ -94,7 +94,7 @@ fun addToCollection(info: DittoHeartbeatInfo, config: DittoHeartbeatConfig, ditt
         "metaData" to metaData,
         "sdk" to info.sdk,
         "_schema" to info.schema,
-        "peerKeyString" to info.peerKeyString
+        "peerKey" to info.peerKeyString
     )
 
     ditto.store.collection(HEARTBEAT_COLLECTION_COLLECTION_NAME).upsert(value = doc)

--- a/DittoHeartbeat/src/main/java/live.ditto.dittoheartbeat/Heartbeat.kt
+++ b/DittoHeartbeat/src/main/java/live.ditto.dittoheartbeat/Heartbeat.kt
@@ -30,7 +30,7 @@ data class DittoHeartbeatInfo(
     val presenceSnapshotDirectlyConnectedPeers: Map<String, Any>,
     val sdk: String,
     val schema: String,
-    val peerKey: String,
+    val peerKeyString: String,
     /**
      * The current state of any `HealthMetric`s tracked by the Heartbeat Tool.
      */
@@ -65,7 +65,7 @@ fun startHeartbeat(ditto: Ditto, config: DittoHeartbeatConfig): Flow<DittoHeartb
                     secondsInterval = config.secondsInterval,
                     sdk = ditto.sdkVersion,
                     schema = HEARTBEAT_COLLECTION_SCHEMA_VALUE,
-                    peerKey = ditto.presence.graph.localPeer.peerKeyString
+                    peerKeyString = ditto.presence.graph.localPeer.peerKeyString
                 )
 
         updateHealthMetrics(config)
@@ -94,7 +94,7 @@ fun addToCollection(info: DittoHeartbeatInfo, config: DittoHeartbeatConfig, ditt
         "metaData" to metaData,
         "sdk" to info.sdk,
         "_schema" to info.schema,
-        "peerKey" to info.peerKey
+        "peerKeyString" to info.peerKeyString
     )
 
     ditto.store.collection(HEARTBEAT_COLLECTION_COLLECTION_NAME).upsert(value = doc)

--- a/DittoPresenceDegradationReporter/src/main/java/live/ditto/presencedegradationreporter/components/PeerItem.kt
+++ b/DittoPresenceDegradationReporter/src/main/java/live/ditto/presencedegradationreporter/components/PeerItem.kt
@@ -40,7 +40,7 @@ fun PeerItem(peer: Peer) {
                 fontWeight = FontWeight.Bold,
             )
 
-            Text(text = stringResource(R.string.key, peer.key))
+            Text(text = stringResource(R.string.key, peer.peerKeyString))
 
             Text(text = stringResource(R.string.last_seen, peer.lastSeenFormatted))
 
@@ -90,7 +90,7 @@ private fun PeerItemConnectedPreview() {
                 ),
                 connected = true,
                 lastSeen = 0L,
-                key = "Key123"
+                peerKeyString = "Key123"
             )
         )
     }

--- a/DittoPresenceDegradationReporter/src/main/java/live/ditto/presencedegradationreporter/model/Peer.kt
+++ b/DittoPresenceDegradationReporter/src/main/java/live/ditto/presencedegradationreporter/model/Peer.kt
@@ -8,7 +8,7 @@ data class Peer(
     val transportInfo: PeerTransportInfo,
     val connected: Boolean,
     val lastSeen: Long,
-    val key: String,
+    val peerKeyString: String,
 ) {
     val lastSeenFormatted = GetDateFromTimestampUseCase().invoke(lastSeen)
 }

--- a/DittoToolsViewer/src/main/java/live/ditto/dittotoolsviewer/presentation/HeartbeatScreen.kt
+++ b/DittoToolsViewer/src/main/java/live/ditto/dittotoolsviewer/presentation/HeartbeatScreen.kt
@@ -110,7 +110,7 @@ fun HeartbeatHeader(heartbeatInfo: DittoHeartbeatInfo) {
             ),
             color = Color.Black
         )
-        Text(stringResource(R.string.heartbeat_peer_key_label, heartbeatInfo.peerKey))
+        Text(stringResource(R.string.heartbeat_peer_key_label, heartbeatInfo.peerKeyString))
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -311,14 +311,14 @@ There are two ways you can access the data:
 This is the model of the data and what you can use for reference
 ```kotlin
 {
-    _id: <ditto peerKey>,
+    _id: <ditto peerKeyString>,
     _schema: String,
     secondsInterval: String,
     presenceSnapshotDirectlyConnectedPeersCount: Int,
     lastUpdated: String (ISO-8601),
     sdk: String,
     presenceSnapshotDirectlyConnectedPeers: {
-        <peerKey>: {
+        <peerKeyString>: {
             deviceName: String,
             sdk: String,
             isConnectedToDittoCloud: Bool,
@@ -326,7 +326,7 @@ This is the model of the data and what you can use for reference
             p2pWifi: Int,
             lan: Int,
         },
-        <peerKey>…,
+        <peerKeyString>…,
         …
     },
     metaData: {},


### PR DESCRIPTION
closes CXTOOLS-203

The actual peerKey calls were already using peerKeyString. This PR simply updates the property name to peerKeyString