### PR TITLE
fix nested scrolling issue with health screen composable

### DIFF
--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/health/ui/composables/HealthScreen.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/health/ui/composables/HealthScreen.kt
@@ -3,8 +3,6 @@ package live.ditto.tools.health.ui.composables
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -16,8 +14,7 @@ fun HealthScreen(
 ) {
     Column(
         modifier = modifier
-            .padding(8.dp)
-            .verticalScroll(state = rememberScrollState()),
+            .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         displayList.forEach { screen ->


### PR DESCRIPTION
Not sure how I missed this one...

I had `LazyColumn`'s inside of a `Column` with vertical scroll. This isn't allowed and will crash with an `IllegalStateException`. This is because the `Column` cannot calculate the height of a `LazyColumn` as it is dynamic and could be infinite.

Found the error with the compatibility app when I also tried to add nested scrolling :(