### PR TITLE
Update README for local changes

### DIFF
--- a/DittoToolsAndroid/build.gradle.kts
+++ b/DittoToolsAndroid/build.gradle.kts
@@ -32,11 +32,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.webkit)
 
-    implementation(libs.live.ditto.ditto) {
-        version {
-            strictly("[4.5.0,)")
-        }
-    }
+    implementation(libs.live.ditto.ditto)
 
     testImplementation(libs.junit.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/DittoToolsAndroid/build.gradle.kts
+++ b/DittoToolsAndroid/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 val libraryArtifactId by extra("ditto-tools-android")

--- a/README.md
+++ b/README.md
@@ -305,20 +305,6 @@ To test your changes to a module in the demo app, make sure to import the local 
 add: `implementation(project(":DittoToolsAndroid"))`
 remove/comment out: `implementation libs.live.ditto.ditto-tools-android`
 
-Update `build.gradle.kts` dependency:
-
-```dependencies
-dependencies {
-    // Other dependencies
-    implementation(libs.live.ditto.ditto) {
-        // version {
-        //    strictly("[4.5.0,)")
-        // }
-    }
-}
-```
-
-
 ### Testing in an External Project
 
 1. Run `./gradlew publishToMavenLocal`

--- a/README.md
+++ b/README.md
@@ -302,8 +302,67 @@ ditto.onlinePlayground.token="YOUR_TOKEN"
 
 To test your changes to a module in the demo app, make sure to import the local module in `app/build.gradle` dependencies section: 
 
-add: `implementation(project(":AndroidDittoTools"))`
+add: `implementation(project(":DittoToolsAndroid"))`
 remove/comment out: `implementation libs.live.ditto.ditto-tools-android`
+
+The latest DittoToolsAndroid build uses Kotlin 2.1.0 if your version is below that you'll have to update this as well. 
+#### Note Kotlin 2.0.0 and above does not come packaged with compose compiler (decoupled) so we will need to manually add that.
+
+In `libs.versions.toml` update the below
+ 
+```versions
+[versions]
+// Update this line
+kotlin-gradle-plugin = "2.1.0"
+androidComposeKotlinCompiler = "2.1.0"
+
+// Add this line
+kotlin = "2.1.0"
+
+[plugins]
+// Add this line
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" } 
+```
+
+In `build.gradle(Module: app)`:
+
+```plugins
+plugins {
+    // Other plugins
+    alias(libs.plugins.compose.compiler)
+}
+```
+
+In `build.gradle(Project: DittoTools)`:
+
+```plugins
+plugins {
+    // Other plugins
+    alias libs.plugins.compose.compiler apply false
+}
+```
+
+In `build.gradle.kts(Module: DittoToolsAndroid)`:
+
+```plugins
+plugins {
+    // Other plugins
+    alias(libs.plugins.compose.compiler)
+}
+
+// Comment out strict versions in dependencies
+dependencies {
+    implementation(libs.live.ditto.ditto) {
+        // version {
+        //     strictly("[4.5.0,)")
+        // }
+    }
+}
+```
+
+For reference to Google documentation:
+[Compose Compiler Gradle plugin](https://developer.android.com/develop/ui/compose/compiler)
+
 
 ### Testing in an External Project
 

--- a/README.md
+++ b/README.md
@@ -305,63 +305,18 @@ To test your changes to a module in the demo app, make sure to import the local 
 add: `implementation(project(":DittoToolsAndroid"))`
 remove/comment out: `implementation libs.live.ditto.ditto-tools-android`
 
-The latest DittoToolsAndroid build uses Kotlin 2.1.0 if your version is below that you'll have to update this as well. 
-#### Note Kotlin 2.0.0 and above does not come packaged with compose compiler (decoupled) so we will need to manually add that.
+Update `build.gradle.kts` dependency:
 
-In `libs.versions.toml` update the below
- 
-```versions
-[versions]
-// Update this line
-kotlin-gradle-plugin = "2.1.0"
-androidComposeKotlinCompiler = "2.1.0"
-
-// Add this line
-kotlin = "2.1.0"
-
-[plugins]
-// Add this line
-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" } 
-```
-
-In `build.gradle(Module: app)`:
-
-```plugins
-plugins {
-    // Other plugins
-    alias(libs.plugins.compose.compiler)
-}
-```
-
-In `build.gradle(Project: DittoTools)`:
-
-```plugins
-plugins {
-    // Other plugins
-    alias libs.plugins.compose.compiler apply false
-}
-```
-
-In `build.gradle.kts(Module: DittoToolsAndroid)`:
-
-```plugins
-plugins {
-    // Other plugins
-    alias(libs.plugins.compose.compiler)
-}
-
-// Comment out strict versions in dependencies
+```dependencies
 dependencies {
+    // Other dependencies
     implementation(libs.live.ditto.ditto) {
         // version {
-        //     strictly("[4.5.0,)")
+        //    strictly("[4.5.0,)")
         // }
     }
 }
 ```
-
-For reference to Google documentation:
-[Compose Compiler Gradle plugin](https://developer.android.com/develop/ui/compose/compiler)
 
 
 ### Testing in an External Project

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     alias libs.plugins.com.android.application
     alias libs.plugins.org.jetbrains.kotlin.android
+    alias(libs.plugins.compose.compiler)
 }
 
 apply from: "$rootProject.projectDir/gradle/android-common.gradle"
@@ -45,7 +46,6 @@ dependencies {
 
     implementation platform(libs.androidx.compose.composeBom)
     implementation(libs.ditto.tools.android)
-
 
     testImplementation libs.junit.junit
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     alias libs.plugins.com.android.application apply false
     alias libs.plugins.com.android.library apply false
     alias libs.plugins.org.jetbrains.kotlin.android apply false
+    alias(libs.plugins.compose.compiler) apply false
 }
 
 version = findProperty("LIBRARY_VERSION")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,11 +15,11 @@ androidx-test-ext = "1.1.5"
 androidx-webkit = "1.7.0"
 datastorePreferences = "1.0.0"
 ditto = "4.9.3"
-ditto-tools-android = "4.0.0"
+ditto-tools-android = "4.0.1"
 
 junit = "4.13.2"
-kotlin-gradle-plugin = "1.8.10"
-androidComposeKotlinCompiler = "1.4.4"
+kotlin-gradle-plugin = "2.1.0"
+androidComposeKotlinCompiler = "2.1.0"
 core-ktx = "1.9.0"
 espresso-core = "3.5.1"
 material = "1.11.0"
@@ -28,6 +28,7 @@ gradle-wrapper = "8.10.2"
 gradle-nexus-publish-plugin = "2.0.0"
 runtimeAndroid = "1.7.6"
 webkit = "1.12.1"
+kotlin = "2.1.0"
 
 [libraries]
 androidx-appcompat-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
@@ -56,3 +57,4 @@ com-android-application = { id = "com.android.application", version.ref = "andro
 com-android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-gradle-plugin" }
 io-github-gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradle-nexus-publish-plugin"}
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Updates the project name from AndroidDittoTools to DittoToolsAndroid.

The latest DittoTools build requires Kotlin 2.1.0, in case one doesn't have that version, we added some instruction on how to do that.