### PR TITLE
(#CXTOOLS413) Add verticalScroll modifier to ToolsMenuItems

### DIFF
--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/ToolsMenu.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/ToolsMenu.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -59,7 +61,7 @@ private fun ToolsMenuItems(
     menuItems: List<ToolMenuItem>
 ) {
     Column(
-        modifier = Modifier.padding(8.dp),
+        modifier = Modifier.padding(8.dp).verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         menuItems.forEach { toolMenuItem ->


### PR DESCRIPTION
Fixes [CXTOOLS-413](https://linear.app/ditto/issue/CXTOOLS-413/bug-android-all-tools-viewer-doesnt-scroll)

Add a verticalScroll modifier to the ToolsMenuItems composable