### PR TITLE
Remove usesCleartextTraffic

### DIFF
--- a/DittoToolsAndroid/src/main/AndroidManifest.xml
+++ b/DittoToolsAndroid/src/main/AndroidManifest.xml
@@ -3,9 +3,4 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-
-    <application
-        android:usesCleartextTraffic="true">
-    </application>
 </manifest>


### PR DESCRIPTION
Related to this [ticket](https://linear.app/ditto/issue/CX-534/check-if-android-manifest-should-default-usescleartexttraffic-to-false).

After running the quickstart app with the tools on two physical devices I saw no issues with setting `usesCleartextTraffic` to false (removing it is equivalent) for any of the tools.