### PR TITLE
Fix/README: Correct image path for export logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ ExportLogsToPortal(ditto: Ditto, onDismiss: () -> Unit)
 
 You'll also be able to use a new public API found at DittoTools.uploadLogsToPortal(ditto: Ditto) that takes a ditto object which will allow you to upload logs from anywhere in your app.
 
-<img src="/Img/exportLogsToPortal.png" alt="Export Logs Image" width="300">
+<img src="/Img/exportLogToPortal.png" alt="Export Logs Image" width="300">
 
 ### 6. Disk Usage/ Export Data
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ ExportLogsToPortal(ditto: Ditto, onDismiss: () -> Unit)
 
 You'll also be able to use a new public API found at DittoTools.uploadLogsToPortal(ditto: Ditto) that takes a ditto object which will allow you to upload logs from anywhere in your app.
 
-<img src="/Img/exportLogToPortal.png" alt="Export Logs Image" width="300">
+<img src="/Img/ExportLogToPortal.png" alt="Export Logs Image" width="300">
 
 ### 6. Disk Usage/ Export Data
 


### PR DESCRIPTION
The image path for the "Export Logs" image was updated to fix a typo, changing it from `exportLogsToPortal.png` to `exportLogToPortal.png`.