### PR TITLE
Implements Export Callback for DiskUsage tool

### DIFF
--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsage.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsage.kt
@@ -9,10 +9,14 @@ import androidx.lifecycle.viewmodel.compose.viewModel
  * Wrapper composable function for `DiskUsageView`.
  */
 @Composable
-fun DiskUsageScreen() {
+fun DiskUsageScreen(
+    onExport: ((java.io.File) -> Unit)? = null
+) {
     val ditto = DittoHandler.ditto
 
-    val viewModel = viewModel<DiskUsageViewModel>()
+    val viewModel = viewModel<DiskUsageViewModel> {
+        DiskUsageViewModel(onExport = onExport)
+    }
     val observerHandle = remember(ditto.diskUsage, viewModel) {
         ditto.diskUsage.observe { diskUsageItem ->
             val children = diskUsageItem.childItems ?: return@observe
@@ -29,7 +33,8 @@ fun DiskUsageScreen() {
     }
     DiskUsageView(
         ditto = ditto,
-        viewModel = viewModel
+        viewModel = viewModel,
+        onExport = onExport
     )
 }
 

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsage.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsage.kt
@@ -4,13 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.io.File
 
 /**
  * Wrapper composable function for `DiskUsageView`.
  */
 @Composable
 fun DiskUsageScreen(
-    onExport: ((java.io.File) -> Unit)? = null
+    onExport: ((File) -> Unit)? = null
 ) {
     val ditto = DittoHandler.ditto
 

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsageView.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsageView.kt
@@ -1,18 +1,15 @@
 package live.ditto.tools.diskusage
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -25,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -42,7 +38,8 @@ private val ScreenTypography = Typography()
 @Composable
 fun DiskUsageView(
     ditto: Ditto,
-    viewModel: DiskUsageViewModel = viewModel()
+    viewModel: DiskUsageViewModel = viewModel(),
+    onExport: ((File) -> Unit)? = null
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -51,6 +48,7 @@ fun DiskUsageView(
         fileProvider = {
             viewModel.exportButtonOnClick(ditto)
         },
+        skipFilePicker = onExport != null
     )
 }
 
@@ -58,35 +56,12 @@ fun DiskUsageView(
 private fun DiskUsageView(
     uiState: DiskUsageState,
     fileProvider: suspend () -> File,
+    skipFilePicker: Boolean = false
 ) {
     var isExportDialogOpen by remember { mutableStateOf(false) }
 
     Surface {
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Row {
-                Text(
-                    text = stringResource(R.string.disk_usage),
-                    style = ScreenTypography.headlineLarge,
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                IconButton(
-                    enabled = !isExportDialogOpen,
-                    onClick = { isExportDialogOpen = true },
-                    modifier = Modifier
-                        .widthIn(min = 60.dp) // Ensure a minimum width for the button
-                        .background(Color.LightGray, shape = RoundedCornerShape(8.dp))
-                        .padding(horizontal = 5.dp)
-                ) {
-                    Text(
-                        text = "Export"
-                    )
-                }
-            }
-
             Spacer(modifier = Modifier.height(24.dp))
 
             LazyColumn(modifier = Modifier.weight(1f)) {
@@ -111,6 +86,18 @@ private fun DiskUsageView(
                 }
             }
 
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                enabled = !isExportDialogOpen,
+                onClick = { isExportDialogOpen = true },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(R.string.export))
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             if (isExportDialogOpen) {
                 ExportDialog(
                     title = stringResource(R.string.export_ditto_directory),
@@ -119,7 +106,8 @@ private fun DiskUsageView(
                     cancelText = stringResource(R.string.cancel),
                     fileProvider = fileProvider,
                     mimeType = stringResource(R.string.application_x_zip),
-                    onDismiss = { isExportDialogOpen = false }
+                    onDismiss = { isExportDialogOpen = false },
+                    skipFilePicker = skipFilePicker
                 )
             }
         }

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsageViewModel.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsageViewModel.kt
@@ -23,6 +23,7 @@ class DiskUsageViewModel(
     private val zipFolderUseCase: ZipFolderUseCase = ZipFolderUseCase(),
     private val dispatcherIO: CoroutineDispatcher = Dispatchers.IO,
     private val getDiskUsageMetrics: GetDiskUsageMetrics = GetDiskUsageMetrics(),
+    private val onExport: ((File) -> Unit)? = null
     ) : ViewModel(), HealthMetricProvider {
     /* Private mutable state */
     private val _uiState = MutableStateFlow(DiskUsageState())
@@ -82,6 +83,9 @@ class DiskUsageViewModel(
             inputDirectory = inputDirectory,
             outputZipFile = outputZipFile
         )
+
+        // Invoke custom callback if provided
+        onExport?.invoke(outputZipFile)
 
         return outputZipFile
     }

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DittoDiskUsage.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DittoDiskUsage.kt
@@ -9,7 +9,10 @@ import androidx.navigation.compose.rememberNavController
 import live.ditto.Ditto
 
 @Composable
-fun DittoDiskUsage(ditto: Ditto) {
+fun DittoDiskUsage(
+    ditto: Ditto,
+    onExport: ((java.io.File) -> Unit)? = null
+) {
     DittoHandler.ditto = ditto
 
     val navController = rememberNavController()
@@ -17,8 +20,8 @@ fun DittoDiskUsage(ditto: Ditto) {
     // A surface container using the 'background' color from the theme
     Surface(color = MaterialTheme.colorScheme.background) {
         NavHost(navController = navController, startDestination = "diskusage") {
-            composable("diskusage") { DiskUsageScreen() }
-            composable("diskUsageView") { DiskUsageView(ditto = ditto) }
+            composable("diskusage") { DiskUsageScreen(onExport = onExport) }
+            composable("diskUsageView") { DiskUsageView(ditto = ditto, onExport = onExport) }
         }
     }
 }

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/DittoToolsViewer.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/DittoToolsViewer.kt
@@ -37,6 +37,7 @@ import live.ditto.tools.presencedegradationreporter.PresenceDegradationReporterS
 import live.ditto.tools.presenceviewer.DittoPresenceViewer
 import live.ditto.tools.toolsviewer.navigation.Screens
 import live.ditto.tools.toolsviewer.viewmodel.ToolsViewerViewModel
+import java.io.File
 
 /**
  * A Composable that you can include in your app that will give a single entry point for all Ditto
@@ -52,12 +53,14 @@ import live.ditto.tools.toolsviewer.viewmodel.ToolsViewerViewModel
 fun DittoToolsViewer(
     modifier: Modifier = Modifier,
     ditto: Ditto,
-    onExitTools: () -> Unit = { }
+    onExitTools: () -> Unit = { },
+    onExport: ((File) -> Unit)? = null
 ) {
     DittoToolsViewerScaffold(
         modifier = modifier,
         ditto = ditto,
-        onExitTools = onExitTools
+        onExitTools = onExitTools,
+        onExport = onExport
     )
 }
 
@@ -67,7 +70,8 @@ private fun DittoToolsViewerScaffold(
     modifier: Modifier,
     ditto: Ditto,
     onExitTools: () -> Unit,
-    viewModel: ToolsViewerViewModel = ToolsViewerViewModel()
+    viewModel: ToolsViewerViewModel = ToolsViewerViewModel(),
+    onExport: ((File) -> Unit)? = null
 ) {
 
     val navController = rememberNavController()
@@ -95,7 +99,8 @@ private fun DittoToolsViewerScaffold(
             navController = navController,
             viewModel = viewModel,
             contentPadding = contentPadding,
-            ditto = ditto
+            ditto = ditto,
+            onExport = onExport
         )
     }
 }
@@ -107,12 +112,14 @@ private fun ToolsViewerContent(
     viewModel: ToolsViewerViewModel,
     contentPadding: PaddingValues,
     ditto: Ditto,
+    onExport: ((File) -> Unit)? = null
 ) {
     ToolsViewerNavHost(
         navController = navController,
         contentPadding = contentPadding,
         ditto = ditto,
-        toolMenuItems = viewModel.toolsMenuItems()
+        toolMenuItems = viewModel.toolsMenuItems(),
+        onExport = onExport
     )
 }
 
@@ -122,7 +129,8 @@ private fun ToolsViewerNavHost(
     navController: NavHostController,
     contentPadding: PaddingValues,
     ditto: Ditto,
-    toolMenuItems: List<ToolMenuItem>
+    toolMenuItems: List<ToolMenuItem>,
+    onExport: ((File) -> Unit)? = null
 ) {
     NavHost(
         modifier = Modifier.padding(contentPadding),
@@ -157,7 +165,7 @@ private fun ToolsViewerNavHost(
                 onDismiss = { navController.popBackStack() })
         }
         composable(Screens.DiskUsageScreen.route) {
-            DittoDiskUsage(ditto = ditto)
+            DittoDiskUsage(ditto = ditto, onExport = onExport)
         }
         composable(Screens.HealthScreen.route) {
             HealthScreen()

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It is available as a Composable element that requires a Ditto instance. Optional
 
 - `modifier`: If you need to adjust the layout
 - `onExitTools`: Lambda function that will be called when the "Exit Tools" button is tapped. Use this to do any back navigation or dismissal of the tools composable if you need to.
+- `onExport`: Lambda function that receives the exported file when using the Disk Usage export feature. Useful for custom export handling on locked-down devices.  Using the onExport parameter overrides the default file picker.
 
 Example code:
 
@@ -58,9 +59,19 @@ import live.ditto.tools.DittoToolsViewer
 DittoToolsViewer(
     ditto = YOUR_DITTO_INSTANCE
 )
+
+// with custom export callback
+DittoToolsViewer(
+    ditto = YOUR_DITTO_INSTANCE,
+    // Using the onExport parameter overrides the default file picker
+    onExport = { file ->
+        // Handle the exported file (e.g., upload to server)
+        uploadToServer(file)
+    }
+)
 ```
 
- <img src="/Img/toolsViewer.png" alt="Tools Viewer Image" width="1000">  
+ <img src="/Img/toolsViewer.png" alt="Tools Viewer Image" width="1000">
 
 To integrate it in a Views-based app - see instructions here: https://developer.android.com/develop/ui/compose/migrate/interoperability-apis/compose-in-views
 
@@ -118,12 +129,24 @@ You'll also be able to use a new public API found at DittoTools.uploadLogsToPort
 
 ### 6. Disk Usage/ Export Data
 
-Disk Usage allows you to see Ditto's file space usage.  
+Disk Usage allows you to see Ditto's file space usage.
 Export Data allows you to export the Ditto directory.
 
 ```kotlin
 DittoDiskUsage(ditto = ditto)
+
+// with custom export callback
+DittoDiskUsage(
+    ditto = ditto,
+    // Using the onExport parameter overrides the default file picker
+    onExport = { file ->
+        // Handle the exported file (e.g., upload to server)
+        uploadToServer(file)
+    }
+)
 ```
+
+The `onExport` callback allows you to provide custom export logic instead of using the default Android file picker. This is particularly useful for locked-down devices where file picker access may be restricted.
 
  <img src="/Img/diskUsage.png" alt="Disk Usage Image" width="300">
 


### PR DESCRIPTION
Adds an optional onExport callback parameter to DittoDiskUsage to allow custom export logic. When a callback is provided, the Android file picker is unused and the exported zip is passed directly to the callback. If no callback is provided, the default file picker will be used

Implements CXTOOLS-544

Demo:
https://www.loom.com/share/806c8b2b155c42a1806c5fbbb75dfdac