### PR TITLE
Updating README.md to reflect updated toolsviewer package path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It is available as a Composable element that requires a Ditto instance. Optional
 Example code:
 
 ```kotlin
-import live.ditto.tools.DittoToolsViewer
+import live.ditto.tools.toolsviewer.DittoToolsViewer
 // minimum code required to get started
 DittoToolsViewer(
     ditto = YOUR_DITTO_INSTANCE


### PR DESCRIPTION
Before
import live.ditto.tools.DittoToolsViewer
After
import live.ditto.tools.toolsviewer.DittoToolsViewer

Test: I use new package path and have been able to import DittoToolsViewer.