### PR TITLE
Downgraded dependencies and related code to SDK 33, Kotlin < 2

### DIFF
--- a/DittoToolsAndroid/build.gradle.kts
+++ b/DittoToolsAndroid/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
-    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.jreleaser)
 }
 
@@ -15,7 +14,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.runtime.android)
     implementation(libs.core.ktx)
     implementation(libs.androidx.appcompat.appcompat)
 

--- a/DittoToolsAndroid/build.gradle.kts
+++ b/DittoToolsAndroid/build.gradle.kts
@@ -14,6 +14,13 @@ android {
 }
 
 dependencies {
+    // Explicit androidx.activity dependencies for SDK 33 compatibility
+    // These are published to the POM and take precedence over transitive dependencies
+    // material:1.10.0 and other libs request 1.8.0+, which requires SDK 34
+    implementation("androidx.activity:activity:1.7.2")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.activity:activity-ktx:1.7.2")
+
     implementation(libs.core.ktx)
     implementation(libs.androidx.appcompat.appcompat)
 

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/databrowser/Collections.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/databrowser/Collections.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
@@ -116,7 +116,7 @@ fun ListItem(collectionName: String, navController: NavHostController, isStandAl
             modifier = Modifier.weight(1f)
         )
         Icon(
-            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+            imageVector = Icons.Filled.ArrowForward,
             contentDescription = "Navigate to Item screen",
             modifier = Modifier.padding(end = 16.dp)
         )

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/databrowser/Documents.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/databrowser/Documents.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
@@ -26,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun Documents(collectionName: String, isStandAlone: Boolean) {
 
@@ -35,7 +37,7 @@ fun Documents(collectionName: String, isStandAlone: Boolean) {
 
     val selectedDoc by viewModel.selectedDoc.observeAsState()
     val docsList by viewModel.docsList.observeAsState()
-    var selectedIndex by remember { mutableIntStateOf(0) }
+    var selectedIndex by remember { mutableStateOf(0) }
     var startUp by remember { mutableStateOf(true) }
 
         Column(
@@ -122,7 +124,7 @@ fun Documents(collectionName: String, isStandAlone: Boolean) {
                 }
             }
 
-            HorizontalDivider()
+            Divider()
 
             LazyColumn {
                 items(viewModel.docProperties.value?.map { it } ?: emptyList()) { property ->

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsageView.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/diskusage/DiskUsageView.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -74,7 +74,7 @@ private fun DiskUsageView(
                 }
 
                 item {
-                    HorizontalDivider(Modifier.padding(vertical = 8.dp))
+                    Divider(Modifier.padding(vertical = 8.dp))
                 }
 
                 item {

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/health/components/HealthCheck.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/health/components/HealthCheck.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -67,7 +67,7 @@ internal fun HealthCheckWithAction(
             style = HealthTypography.bodyMedium
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+        Divider(modifier = Modifier.padding(vertical = 4.dp))
 
         OutlinedButton(
             onClick = onAction,

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/Dashboard.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/Dashboard.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Divider
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -63,7 +63,7 @@ fun Dashboard(
             onChangeClick = onChangeClick,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
 
         if (localPeer != null) {
             Text(

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeerItem.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeerItem.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -44,7 +44,7 @@ fun PeerItem(peer: Peer) {
 
             Text(text = stringResource(R.string.last_seen, peer.lastSeenFormatted))
 
-            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+            Divider(modifier = Modifier.padding(vertical = 4.dp))
             Transports(
                 transportInfo = peer.transportInfo,
                 isConnected = peer.connected

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeersForm.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeersForm.kt
@@ -9,12 +9,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -27,13 +27,14 @@ import androidx.compose.ui.unit.dp
 import live.ditto.tools.R
 import live.ditto.tools.presencedegradationreporter.theme.PresenceDegradationReporterTheme
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PeersForm(
     expectedPeers: Int,
     reportApiEnabled: Boolean,
     onSave: (expectedPeers: Int, reportApiEnabled: Boolean) -> Unit
 ) {
-    var peers by remember(expectedPeers) { mutableIntStateOf(expectedPeers) }
+    var peers by remember(expectedPeers) { mutableStateOf(expectedPeers) }
     var apiEnabled by remember(reportApiEnabled) { mutableStateOf(reportApiEnabled) }
     var isError by remember { mutableStateOf(false) }
 

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/DittoToolsViewer.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/DittoToolsViewer.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -140,7 +140,7 @@ private fun DittoToolsViewerScaffold(
                 navigationIcon = {
                     IconButton(onClick = handleBackNavigation) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.Filled.ArrowBack,
                             contentDescription = if (isMainScreen) {
                                 stringResource(R.string.exit_tools_content_description)
                             } else {
@@ -157,7 +157,7 @@ private fun DittoToolsViewerScaffold(
                         )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
+                colors = TopAppBarDefaults.mediumTopAppBarColors(
                     containerColor = statusBarColor,
                     titleContentColor = contentColor,
                     navigationIconContentColor = contentColor,

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/ToolsMenu.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/ToolsMenu.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
@@ -99,6 +100,7 @@ fun ToolsMenu(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun ToolMenuItem(
     name: String,

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/viewmodel/ToolsViewerViewModel.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/toolsviewer/viewmodel/ToolsViewerViewModel.kt
@@ -1,7 +1,7 @@
 package live.ditto.tools.toolsviewer.viewmodel
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.HealthAndSafety
@@ -31,7 +31,7 @@ class ToolsViewerViewModel: ViewModel() {
                     ToolMenuItem(
                         label = R.string.peers_list_tool_label,
                         route = Screens.PeersListViewerScreen.route,
-                        icon = Icons.AutoMirrored.Filled.List
+                        icon = Icons.Filled.List
                     ),
                     ToolMenuItem(
                         label = R.string.presence_degradation_reporter_tool_label,

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     alias libs.plugins.com.android.application
     alias libs.plugins.org.jetbrains.kotlin.android
-    alias(libs.plugins.compose.compiler)
 }
 
 apply from: "$rootProject.projectDir/gradle/android-common.gradle"

--- a/app/src/main/java/live/ditto/dittotoolsapp/MainActivity.kt
+++ b/app/src/main/java/live/ditto/dittotoolsapp/MainActivity.kt
@@ -6,14 +6,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -22,9 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import live.ditto.Ditto
 import live.ditto.dittotoolsapp.ui.theme.DittoToolsAppTheme
@@ -76,26 +70,6 @@ class MainActivity : ComponentActivity() {
         if (missing.isNotEmpty()) {
             requestPermissions(missing, 0)
             app.getDittoOrNull()?.refreshPermissions()
-        }
-    }
-}
-
-
-@Composable
-private fun DittoError(text: String) {
-    DittoToolsAppTheme {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Column(
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .align(Alignment.Center)
-            ) {
-                Text(
-                    text = "Ditto Error", fontWeight = FontWeight.Bold
-                )
-                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                Text(text = text)
-            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     alias libs.plugins.com.android.application apply false
     alias libs.plugins.com.android.library apply false
     alias libs.plugins.org.jetbrains.kotlin.android apply false
-    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.jreleaser) apply false
 }
 
@@ -25,6 +24,28 @@ ext.getValueFromLocalProperties = { name, defValue ->
     def prop = project.properties[name] ?:
             getValueFromPropertiesFile(project.rootProject.file('local.properties'), name)
     return (null == prop) ? defValue : prop
+}
+
+subprojects {
+    configurations.configureEach {
+        resolutionStrategy.eachDependency { details ->
+            // Force androidx.activity to 1.7.2 for SDK 33 compatibility
+            if (details.requested.group == "androidx.activity") {
+                details.useVersion("1.7.2")
+                details.because("SDK 33 compatibility - 1.8.0+ requires API 34")
+            }
+            // Force material3 to 1.0.1 to avoid v34 resources
+            if (details.requested.group == "androidx.compose.material3" && details.requested.name == "material3") {
+                details.useVersion("1.0.1")
+                details.because("SDK 33 compatibility - 1.1.0+ includes API 34 only resources")
+            }
+            // Force material to 1.10.0 to avoid v34 resources
+            if (details.requested.group == "com.google.android.material" && details.requested.name == "material") {
+                details.useVersion("1.10.0")
+                details.because("SDK 33 compatibility - 1.11.0+ includes API 34 only resources")
+            }
+        }
+    }
 }
 
 // Built-in task

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext.getValueFromLocalProperties = { name, defValue ->
     return (null == prop) ? defValue : prop
 }
 
+// This only enforces dependency constraints for subprojects in Ditto Tools, not on consuming projects
 subprojects {
     configurations.configureEach {
         resolutionStrategy.eachDependency { details ->

--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,10 @@ subprojects {
                 details.useVersion("1.0.1")
                 details.because("SDK 33 compatibility - 1.1.0+ includes API 34 only resources")
             }
-            // Force material to 1.10.0 to avoid v34 resources
+            // Force material to 1.9.0 to avoid v34 dependencies
             if (details.requested.group == "com.google.android.material" && details.requested.name == "material") {
-                details.useVersion("1.10.0")
-                details.because("SDK 33 compatibility - 1.11.0+ includes API 34 only resources")
+                details.useVersion("1.9.0")
+                details.because("SDK 33 compatibility - 1.10.0+ requires androidx.activity:1.8.0 which needs API 34")
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,32 +3,27 @@
 [versions]
 # https://developer.android.com/studio/releases/gradle-plugin
 android-gradle-plugin = "8.7.1"
-android-sdk = "34"
+android-sdk = "33"
 android-minsdk = "23"
 
-androidx-activity = "1.7.1"
 androidx-appcompat = "1.6.1"
 # Compose 1.6.8 - https://developer.android.com/develop/ui/compose/bom/bom-mapping
-androidx-compose = "2024.06.00"
+androidx-compose = "2023.06.01"
 androidx-navigation = "2.5.3"
 androidx-test-ext = "1.1.5"
-androidx-webkit = "1.7.0"
+webkit = "1.7.0"
 datastorePreferences = "1.0.0"
 ditto = "4.11.6"
-ditto-tools-android = "4.0.1"
 
 junit = "4.13.2"
-kotlin-gradle-plugin = "2.1.0"
-androidComposeKotlinCompiler = "2.1.0"
+kotlin-gradle-plugin = "1.9.25"
+androidComposeKotlinCompiler = "1.5.15"
 core-ktx = "1.9.0"
 espresso-core = "3.5.1"
-material = "1.11.0"
+material = "1.10.0"
 
 gradle-wrapper = "8.10.2"
-gradle-nexus-publish-plugin = "2.0.0"
-runtimeAndroid = "1.7.6"
-webkit = "1.12.1"
-kotlin = "2.1.0"
+kotlin = "1.9.25"
 jreleaser = "1.20.0"
 
 [libraries]
@@ -44,20 +39,16 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose" }
 androidx-navigation-navigationCompose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidx-navigation" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext" }
-ditto-tools-android = { module = "live.ditto:ditto-tools-android", version.ref = "ditto-tools-android" }
 live-ditto-ditto = { group = "live.ditto", name = "ditto", version.ref = "ditto" }
 junit-junit = { group = "junit", name = "junit", version.ref = "junit" }
 joda-time-joda-time = { group = "joda-time", name = "joda-time", version = "2.10.10" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtimeAndroid" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 com-android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-gradle-plugin" }
-io-github-gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradle-nexus-publish-plugin"}
-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlin-gradle-plugin = "1.9.25"
 androidComposeKotlinCompiler = "1.5.15"
 core-ktx = "1.9.0"
 espresso-core = "3.5.1"
-material = "1.10.0"
+material = "1.9.0"
 
 gradle-wrapper = "8.10.2"
 kotlin = "1.9.25"


### PR DESCRIPTION
  - Downgraded compileSdk and targetSdk from 34 to 33, along with Compose BOM (2023.06.01) and Material library (1.10.0) to avoid API 34-only resources
  - Downgraded Kotlin from 2.1.0 to 1.9.25 with Compose compiler 1.5.15 for compatibility with Kotlin 1.x consumers
  - Added dependency resolution strategies to force SDK 33-compatible versions of androidx.activity (1.7.2), material3 (1.0.1), and material (1.10.0)
  - Updated Compose APIs: replaced HorizontalDivider with Divider and Icons.AutoMirrored.* with Icons.Filled.* for Compose 1.4.x compatibility
  
  Fixes CXTOOLS-212