### PR TITLE
Convert experimental text field to stable basic text field

### DIFF
--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeersForm.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeersForm.kt
@@ -1,18 +1,21 @@
 package live.ditto.tools.presencedegradationreporter.components
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,14 +23,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import live.ditto.tools.R
 import live.ditto.tools.presencedegradationreporter.theme.PresenceDegradationReporterTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PeersForm(
     expectedPeers: Int,
@@ -39,23 +39,38 @@ fun PeersForm(
     var isError by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        Column(modifier = Modifier.align(Alignment.Center)) {
-            TextField(
-                label = { Text(stringResource(R.string.expected_number_of_peers_in_the_mesh)) },
+        Column(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                "Expected minimum number of peers in the mesh:"
+            )
+            BasicTextField(
                 value = peers.toString(),
                 onValueChange = {
                     peers = parseNumber(it)
                     isError = false
                 },
                 keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-                isError = isError,
-                supportingText = {
-                    if (isError) {
-                        Text("Value must be greater than zero.")
-                    }
-                }
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 1.dp,
+                        color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(4.dp)
+                    )
+                    .padding(16.dp)
             )
-
+            if (isError) {
+                Text(
+                    text = "Value must be greater than zero.",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                )
+            }
             Spacer(modifier = Modifier.height(16.dp))
 
             Row(

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeersForm.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/presencedegradationreporter/components/PeersForm.kt
@@ -23,9 +23,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import live.ditto.tools.R
 import live.ditto.tools.presencedegradationreporter.theme.PresenceDegradationReporterTheme
 
 @Composable
@@ -44,9 +46,7 @@ fun PeersForm(
                 .align(Alignment.Center)
                 .padding(horizontal = 16.dp),
         ) {
-            Text(
-                "Expected minimum number of peers in the mesh:"
-            )
+            Text(stringResource(R.string.expected_number_of_peers_in_the_mesh))
             BasicTextField(
                 value = peers.toString(),
                 onValueChange = {


### PR DESCRIPTION
Related to Zendesk Ticket [2667](https://dittosync.zendesk.com/agent/tickets/2667).
When opening the Presence Degradation Reporter an app integrating the tools would crash (but the tools alone would not). 
This could be reproduced by putting the tools into the QS app. 
My theory is that since the `TextField` component is marked as experimental in the version of material3 we are using the API changed in later versions and apps could implicitly upgrade it causing the crash.

We can't upgrade as we are maintaining compatibility with API v33 and forcing users to use an older version of material3 is not desirable.

My solution is to change the page slightly to use the the stable `BasicTextField` this stops the crash.
| Before    | After |
| -------- | ------- |
|  <img width="526" height="1144" alt="image" src="https://github.com/user-attachments/assets/ac29e8b1-86d3-4b8d-87a7-3be0bbbdf320" /> | <img width="556" height="1210" alt="image" src="https://github.com/user-attachments/assets/20df4233-53ab-4804-9e2e-1003cda14e88" />|