### PR TITLE
Handle unknown SDK version gracefully in peers list and heartbeat

### DIFF
--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/heartbeat/Heartbeat.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/heartbeat/Heartbeat.kt
@@ -113,7 +113,7 @@ fun getConnections(
 
         val connectionMap: Map<String, Any?> = mapOf(
             "deviceName" to connection.deviceName,
-            "sdk" to ditto.sdkVersion,
+            "sdk" to (connection.dittoSdkVersion ?: ditto.sdkVersion),
             "isConnectedToDittoCloud" to connection.isConnectedToDittoCloud,
             "bluetooth" to connectionsTypeMap["bt"],
             "p2pWifi" to connectionsTypeMap["p2pWifi"],

--- a/DittoToolsAndroid/src/main/java/live/ditto/tools/peerslist/PeersListViewer.kt
+++ b/DittoToolsAndroid/src/main/java/live/ditto/tools/peerslist/PeersListViewer.kt
@@ -137,7 +137,12 @@ private fun PeerView(peer: DittoPeer) {
             Column {
                 Text("${peer.deviceName}:", style = MaterialTheme.typography.titleLarge)
                 Text(peer.peerKeyString)
-                peer.dittoSdkVersion?.let { Text(stringResource(R.string.sdk_version, it)) }
+                val sdkVersion = peer.dittoSdkVersion
+                if (sdkVersion != null) {
+                    Text(stringResource(R.string.sdk_version, sdkVersion))
+                } else {
+                    Text(stringResource(R.string.sdk_version_unknown))
+                }
             }
         }
     }

--- a/DittoToolsAndroid/src/main/res/values/strings.xml
+++ b/DittoToolsAndroid/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="local_self_peer">LOCAL (SELF) PEER</string>
     <string name="remote_peers">REMOTE PEERS</string>
     <string name="sdk_version">SDK v%1$s</string>
+    <string name="sdk_version_unknown">SDK version unknown</string>
     <string name="logs_will_be_exported_to_portal_for_appid">Logs will be exported to Portal for appID: %1$s</string>
     <string name="exporting">Exporting…</string>
     <string name="export_requested_successfully">Export requested successfully</string>


### PR DESCRIPTION
## Summary
Improved handling of unknown SDK versions across the peers list UI and heartbeat telemetry by adding explicit null checks and fallback values.

## Key Changes
- **PeersListViewer.kt**: Replaced the concise `?.let` expression with an explicit null check that displays "SDK version unknown" when `dittoSdkVersion` is null, providing better UX feedback
- **Heartbeat.kt**: Updated the connection map to use the peer's SDK version when available, falling back to the local Ditto SDK version as a default
- **strings.xml**: Added new string resource `sdk_version_unknown` for displaying when a peer's SDK version information is unavailable

## Implementation Details
The changes ensure that:
1. Users see a clear message when a remote peer's SDK version cannot be determined, rather than having the field omitted
2. Heartbeat telemetry includes the most accurate SDK version information available (peer-specific when present, otherwise local)
3. The fallback behavior maintains backward compatibility while improving data completeness

https://claude.ai/code/session_01BcPUrCDTy3kUi5QhxaZkbN