### PR TITLE
Update CODEOWNERS: replace legacy dittotools team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
 
-* @getditto/dittotools
+* @getditto/sdk-kotlin-engineers @skylerjokiel


### PR DESCRIPTION
## Summary

- Replace legacy `@getditto/dittotools` team with `@getditto/sdk-kotlin-engineers` and `@skylerjokiel` (SDKs product owner) in CODEOWNERS
- The `dittotools` team is a legacy team that no longer reflects current ownership