### PR TITLE
Migrate ditto.live links to ditto.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DittoAndroidTools are diagnostic tools for Ditto. You can view connected peers, 
 
 These tools are available via Maven Central.
 
-For support, please contact Ditto Support (<support@ditto.live>).
+For support, please contact Ditto Support (<support@ditto.com>).
 
 ## Requirements
 

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -49,7 +49,7 @@ afterEvaluate {
                 pom {
                     name = 'Ditto Tools'
                     description = 'Ditto Tools'
-                    url = 'https://ditto.live'
+                    url = 'https://www.ditto.com'
 
                     licenses {
                         license {
@@ -62,7 +62,7 @@ afterEvaluate {
                     scm {
                         connection = 'scm:git:github.com/getditto/DittoAndroidTools.git'
                         developerConnection = 'scm:git:ssh://github.com/getditto/DittoAndroidTools.git'
-                        url = 'https://ditto.live'
+                        url = 'https://www.ditto.com'
                     }
 
                     developers {

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -69,7 +69,7 @@ afterEvaluate {
                         developer {
                             id = 'ditto'
                             name = 'Ditto'
-                            email = 'support@ditto.live'
+                            email = 'support@ditto.com'
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Updates README support contact and Maven publishing developer email from `support@ditto.live` to `support@ditto.com`.
- Updates Maven POM `url` and `scm.url` in `gradle/deploy.gradle` from `https://ditto.live` to `https://www.ditto.com`.